### PR TITLE
fix: race condition in read_stdin

### DIFF
--- a/dtao.c
+++ b/dtao.c
@@ -368,7 +368,7 @@ static void
 read_stdin(void)
 {
 	/* Read as much data as we can into line buffer */
-	ssize_t b = read(STDIN_FILENO, line, MAX_LINE_LEN - 1);
+	ssize_t b = read(STDIN_FILENO, line + linerem, MAX_LINE_LEN - 1 - linerem);
 	if (b < 0)
 		EBARF("read");
 	if (b == 0) {


### PR DESCRIPTION
The easiest way to reproduce this bug:

```
while true; do
  printf hello
  sleep 1
  printf "\n"
  sleep 1
done | dtao -z -z
```

This code would not display "hello" because `read_stdin` overwrote existing line content.

PS: I didn't include it in my commit, but I think that `MAX_LINE_LEN` should be the maximum line length (i.e. without the terminating null byte) as it makes the code more understandable. For example: `strlen(...)` returns the line length and also does not include the null byte.