### PR TITLE
Position commands

### DIFF
--- a/doc/dtao.1.ronn
+++ b/doc/dtao.1.ronn
@@ -114,7 +114,7 @@ Note: the positioning of graphics in dzen is not obvious.  dtao may opt to imple
     relative positioning: calculate X and/or Y position according to the argument format and add it to the current position
 
 * `^p()`:
-    resets Y position to default; alias for `^pa(;0)`
+    resets Y position to default; alias for `^pa(;w50)`
 
 * `^p(_LEFT)`, `^p(_CENTER)`, `^p(_RIGHT)`:
     move to left edge, center, or right edge of window; aliases for `^pa(w0)`, `^pa(w50)`, and `^pa(w100)`

--- a/doc/dtao.1.ronn
+++ b/doc/dtao.1.ronn
@@ -105,7 +105,7 @@ Note: the positioning of graphics in dzen is not obvious.  dtao may opt to imple
     draw circle outline centered at current position, moving right by <diameter> pixels
 
 
-### Positioning [UNIMPLEMENTED]
+### Positioning
 
 * `^pa(`<x>`)`, `^pa(;`<y>`)`, `^pa(`<x>`;`<y>`)`:
     absolute positioning: set X and/or Y position according to the argument format (see below)

--- a/dtao.c
+++ b/dtao.c
@@ -149,6 +149,12 @@ parse_movement_arg(const char *str, uint32_t max)
 	if (*str == 'w')
 		return atoi(++str) * max / 100;
 
+	if (*str == 'd')
+		return atoi(++str) * font->descent / 100;
+
+	if (*str == 'a')
+		return atoi(++str) * font->ascent / 100;
+
 	return atoi(str);
 }
 

--- a/dtao.c
+++ b/dtao.c
@@ -58,6 +58,8 @@ static enum align titlealign, subalign;
 static bool expand;
 static bool run_display = true;
 
+static uint32_t savedx = 0;
+
 static struct fcft_font *font;
 static char line[MAX_LINE_LEN];
 static char lastline[MAX_LINE_LEN];
@@ -182,8 +184,12 @@ handle_cmd(char *cmd, pixman_color_t *bg, pixman_color_t *fg, uint32_t *xpos)
 			fprintf(stderr, "Bad color string \"%s\"\n", arg);
 		}
 	} else if (!strcmp(cmd, "pa")) {
-		if(parse_movement_absolute (arg, xpos))
+		if (parse_movement_absolute (arg, xpos))
 			fprintf(stderr, "Invalid absolute motion argument \"%s\"\n", arg);
+	} else if (!strcmp(cmd, "sx")) {
+		savedx = *xpos;
+	} else if (!strcmp(cmd, "rx")) {
+		*xpos = savedx;
 	} else {
 		fprintf(stderr, "Unrecognized command \"%s\"\n", cmd);
 	}


### PR DESCRIPTION
This implements the position commands from the manpage. The parser could use a few more checks to alert the user of bad arguments to ^p() and ^pa() and handle them more gracefully than by setting the position(s) to 0 or the maximum. Let me know what you think.
