### PR TITLE
Update fcft

### DIFF
--- a/dtao.c
+++ b/dtao.c
@@ -233,7 +233,7 @@ draw_frame(char *text)
 
 		/* Turn off subpixel rendering, which complicates things when
 		 * mixed with alpha channels */
-		const struct fcft_glyph *glyph = fcft_glyph_rasterize(font, codepoint,
+		const struct fcft_glyph *glyph = fcft_rasterize_char_utf32(font, codepoint,
 				FCFT_SUBPIXEL_NONE);
 		if (!glyph)
 			continue;
@@ -570,6 +570,7 @@ main(int argc, char **argv)
 		BARF("compositor does not support all needed protocols");
 
 	/* Load selected font */
+	fcft_init(FCFT_LOG_COLORIZE_AUTO, 0, FCFT_LOG_CLASS_ERROR);
 	fcft_set_scaling_filter(FCFT_SCALING_FILTER_LANCZOS3);
 	font = fcft_from_name(1, (const char *[]) {fontstr}, NULL);
 	if (!font)
@@ -603,6 +604,7 @@ main(int argc, char **argv)
 	wl_surface_destroy(wl_surface);
 	zwlr_layer_shell_v1_destroy(layer_shell);
 	fcft_destroy(font);
+	fcft_fini();
 	wl_shm_destroy(shm);
 	wl_compositor_destroy(compositor);
 	wl_registry_destroy(registry);


### PR DESCRIPTION
Since fcft-3.0.0 fcft_init() and fcft_fini() must be called
also fcft_glyph_rasterize() has been renamed to
fcft_rasterize_char_utf32()